### PR TITLE
Add attribute param to element macro 

### DIFF
--- a/spec/locate_elements_spec.cr
+++ b/spec/locate_elements_spec.cr
@@ -7,8 +7,11 @@ session = WebdriverSessionHelper.session
 class ToDoListPageForElementLocators < WebdriverPump::Page
   url "#{WebdriverSessionHelper.base_url}/todo_list.html"
 
+  element :index_link, {locator: {link_text: "index page"}, attribute: "href"}
   element :title, {locator: {xpath: "//div[@role='title']"}}
   element :fill_item, {locator: {xpath: "//input[@role='new_item']"}}
+
+  elements :divs_role, {locator: {tag_name: "div"}, attribute: "role"}
   elements :items, {locator: {xpath: "//span[@role='name']"}}
   elements :items_lambda, {locator: ->{ root.find_child_elements(:xpath, "//span[@role='name']") }}
 end
@@ -27,6 +30,20 @@ describe WebdriverPump do
     ToDoListPageForElementLocators.new(session).open do |p|
       p.fill_item.displayed?.should be_true
       p.fill_item.class.should eq Selenium::Element
+    end
+  end
+
+  it "property value from element" do
+    expected_url = "#{WebdriverSessionHelper.base_url}/index.html"
+    ToDoListPageForElementLocators.new(session).open do |p|
+      p.index_link.should eq expected_url
+    end
+  end
+
+  it "property value from mutiple elements" do
+    expected_roles = %w[todo_list title]
+    ToDoListPageForElementLocators.new(session).open do |p|
+      p.divs_role.should eq expected_roles
     end
   end
 

--- a/src/webdriver_pump/component.cr
+++ b/src/webdriver_pump/component.cr
@@ -34,6 +34,13 @@ module WebdriverPump
       def {{name.id}}(*args)
         element = locate_element({{params[:locator]}})
 
+        {% if params[:attribute] %}
+          # Arbitrary choice to always try to get the dynamic prop. value first
+          attr = element.property {{params[:attribute]}}
+          attr ||= element.attribute {{params[:attribute]}}
+          return attr
+        {% end %}
+
         {% if params[:class] %}
           element = {{params[:class]}}.new(session, element)
         {% end %}
@@ -49,6 +56,14 @@ module WebdriverPump
     macro elements(name, params)
       def {{name.id}}(*args)
         elements = locate_elements({{params[:locator]}})
+
+        {% if params[:attribute] %}
+          return elements.map do |element|
+            # Arbitrary choice to always try to get the dynamic prop. value first
+            attr = element.property {{params[:attribute]}}
+            attr ||= element.attribute {{params[:attribute]}}
+          end
+        {% end %}
 
         {% if params[:class] %}
           elements = elements.map do |element|


### PR DESCRIPTION
Update element macro in `src/webdriver_pump/component.cr`  to be able to get only the property or attribute value from the located element(s).
The return will always be a String and Array<String> for elements